### PR TITLE
Potential fix for code scanning alert no. 1: Log entries created from user input

### DIFF
--- a/src/DemoShop.Api/Common/Configurations/RateLimitingConfiguration.cs
+++ b/src/DemoShop.Api/Common/Configurations/RateLimitingConfiguration.cs
@@ -42,7 +42,8 @@ public static class RateLimitingConfiguration
             {
                 var logger = context.HttpContext.RequestServices.GetRequiredService<ILogger>();
                 var ipAddress = context.HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
-                var endpoint = context.HttpContext.Request.Method + " " + context.HttpContext.Request.Path.ToString();
+                var rawEndpoint = context.HttpContext.Request.Method + " " + context.HttpContext.Request.Path.ToString();
+                var endpoint = rawEndpoint.Replace("\n", "").Replace("\r", "");
 
                 LogRateLimitExceeded(logger, ipAddress, endpoint);
 


### PR DESCRIPTION
Potential fix for [https://github.com/christian-wandling/demo-shop-dotnet-api/security/code-scanning/1](https://github.com/christian-wandling/demo-shop-dotnet-api/security/code-scanning/1)

To fix the issue, the user-provided `endpoint` value should be sanitized before being logged. Since the log entries are likely stored as plain text, we should remove newline characters and other potentially problematic characters from the `endpoint` string. This can be achieved using `String.Replace` or similar methods to ensure that the log entry cannot be manipulated by malicious input.

The fix involves:
1. Sanitizing the `endpoint` variable by replacing newline characters (`\n` and `\r`) with empty strings.
2. Updating the `LogRateLimitExceeded` method to use the sanitized `endpoint` value.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
